### PR TITLE
replace cjson with json-c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ pkg_check_modules(NYX nyx REQUIRED)
 pkg_check_modules(PBNJSON_CPP pbnjson_cpp REQUIRED)
 pkg_check_modules(SQLITE3 sqlite3 REQUIRED)
 pkg_check_modules(PMLOGLIB PmLogLib REQUIRED)
-pkg_check_modules(CJSON cjson REQUIRED)
+pkg_check_modules(JSON json-c REQUIRED)
 
 include_directories(
     ${GLIB2_INCLUDE_DIRS}
@@ -53,7 +53,7 @@ include_directories(
     ${PBNJSON_CPP_INCLUDE_DIRS}
     ${SQLITE3_INCLUDE_DIRS}
     ${PMLOGLIB_INCLUDE_DIRS}
-    ${CJSON_INCLUDE_DIRS}
+    ${JSON_INCLUDE_DIRS}
     ${CMAKE_SOURCE_DIR}/Src/base
     ${CMAKE_SOURCE_DIR}/Src/base/application
     ${CMAKE_SOURCE_DIR}/Src/base/hosts
@@ -105,7 +105,7 @@ target_link_libraries(LunaSysMgrCommon
     ${PBNJSON_CPP_LIBRARIES}
     ${SQLITE3_LIBRARIES}
     ${PMLOGLIB_LIBRARIES}
-    ${CJSON_LIBRARIES}
+    ${JSON_LIBRARIES}
     pthread)
 qt5_use_modules(LunaSysMgrCommon Core Gui Widgets)
 

--- a/Src/base/Utils.cpp
+++ b/Src/base/Utils.cpp
@@ -31,8 +31,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <glib.h>
-#include <cjson/json.h>
-#include <cjson/json_util.h>
+#include <json.h>
+#include <json/json_util.h>
 #include <algorithm>
 #include <fcntl.h>
 

--- a/Src/base/application/ApplicationDescription.cpp
+++ b/Src/base/application/ApplicationDescription.cpp
@@ -19,7 +19,7 @@
 
 #include "Common.h"
 
-#include <cjson/json.h>
+#include <json.h>
 
 #include "ApplicationDescription.h"
 

--- a/Src/base/application/ApplicationDescriptionBase.cpp
+++ b/Src/base/application/ApplicationDescriptionBase.cpp
@@ -16,7 +16,7 @@
 *
 * LICENSE@@@ */
 
-#include <cjson/json.h>
+#include <json.h>
 #include <stdio.h>
 
 #include "Common.h"

--- a/Src/base/hosts/HostArm.cpp
+++ b/Src/base/hosts/HostArm.cpp
@@ -48,7 +48,7 @@
 #include <QGraphicsView>
 #endif // USE_MOUSE_FILTER
 
-#include <cjson/json.h>
+#include <json.h>
 
 #include "CustomEvents.h"
 #include "Time.h"

--- a/Src/base/settings/DeviceInfo.cpp
+++ b/Src/base/settings/DeviceInfo.cpp
@@ -32,7 +32,7 @@
 #include <lunaprefs.h>
 #endif
 
-#include <cjson/json.h>
+#include <json.h>
 
 static DeviceInfo* s_instance = 0;
 static const int kTouchableHeight = 48;

--- a/Src/base/settings/LocalePreferences.cpp
+++ b/Src/base/settings/LocalePreferences.cpp
@@ -25,7 +25,7 @@
 #include "Settings.h"
 
 #include <sqlite3.h>
-#include <cjson/json.h>
+#include <json.h>
 
 #include "HostBase.h"
 #include "Logging.h"
@@ -591,8 +591,10 @@ bool LocalePreferences::getLocaleInfoCallback(LSHandle *sh,
         goto Done;
     }
 
-    json_object_object_foreach(localesObj, keyName, valueName) {
-        newLocales.insert(keyName, json_object_get_string(valueName));
+    {
+        json_object_object_foreach(localesObj, keyName, valueName) {
+            newLocales.insert(keyName, json_object_get_string(valueName));
+        }
     }
 
     lp->m_mutex.lock();

--- a/Src/base/settings/Preferences.cpp
+++ b/Src/base/settings/Preferences.cpp
@@ -27,7 +27,7 @@
 #include "Settings.h"
 
 #include <sqlite3.h>
-#include <cjson/json.h>
+#include <json.h>
 
 #include "HostBase.h"
 #include "Logging.h"

--- a/Src/core/KeywordMap.cpp
+++ b/Src/core/KeywordMap.cpp
@@ -24,7 +24,7 @@
 #include <string.h>
 #include "KeywordMap.h"
 
-#include "cjson/json.h"
+#include <json.h>
 
 /// ------------------------------------ public: -----------------------------------------------------------------------
 

--- a/Src/nyx/NyxSensorConnector.cpp
+++ b/Src/nyx/NyxSensorConnector.cpp
@@ -25,7 +25,7 @@
 #include <QWidget>
 #include <QMap>
 
-#include <cjson/json.h>
+#include <json.h>
 #include <glib.h>
 
 #define CHECK_ERROR(err, msg)                                                                               \


### PR DESCRIPTION
- call json_object_object_foreach from inside own block
  Otherwise it fails with:
  In file included from sysroots/qemux86/usr/include/cjson/linkhash.h:16:0,
                   from sysroots/qemux86/usr/include/cjson/json.h:22,
                   from ../git/Src/base/settings/LocalePreferences.cpp:27:
  ../git/Src/base/settings/LocalePreferences.cpp:593:5: error:   crosses
    initialization of 'lh_entry\* entry_nextkeyName'
       json_object_object_foreach(localesObj, keyName, valueName) {
       ^
  ../git/Src/base/settings/LocalePreferences.cpp:645:1: warning: jump to
    label 'Done' [-fpermissive]
  Done:
  ^
  ../git/Src/base/settings/LocalePreferences.cpp:584:14: warning:   from
    here [-fpermissive]
           goto Done;
                ^

Change-Id: Icb17d23a6d1c5b580c1b2a6bc735787ba537badc
Signed-off-by: Martin Jansa Martin.Jansa@gmail.com
