### PR TITLE
Disable check for radioType

### DIFF
--- a/Src/base/settings/DeviceInfo.cpp
+++ b/Src/base/settings/DeviceInfo.cpp
@@ -162,6 +162,8 @@ void DeviceInfo::gatherInfo()
 
 
 	// RadioType and carrier availability -----------------------------------------
+/*
+//We don't use /dev/tokens/RadioType anymore, so disabling it for now
     gchar* buffer;
     gsize sz;
     int token = 0;
@@ -175,7 +177,7 @@ void DeviceInfo::gatherInfo()
         g_free(buffer);
         m_radioType = token;
     }
-
+*/
 /*	
 	// Storage --------------------------------------------------------------------
 

--- a/include/DeviceInfo.h
+++ b/include/DeviceInfo.h
@@ -39,7 +39,7 @@ public:
 	bool coreNaviButton() const;
 	bool wifiAvailable() const { return m_wifiAvailable; }
 	bool bluetoothAvailable() const { return m_bluetoothAvailable; }
-	bool carrierAvailable() const {return (m_radioType != 0);}
+	bool carrierAvailable() const {return true;} //FIXME, only need to return in case we have a radio (m_radioType != 0)
 	bool compassAvailable() const { return false; } // FIXME
 	bool accelerometerAvailable() const { return true; } // FIXME
 	bool dockModeEnabled() const { return true; }


### PR DESCRIPTION
We don't use radioType currently, so we don't want to check for it. We'll return carrierAvailable as true for now since the majority of targets have cellular modem. This needs to be properly fixed with oFono/ConnMan sometime in the future.
