### PR TITLE
(Locale)Preferences.cpp: Fix NULL handle for LSRegister

### DIFF
--- a/Src/base/settings/LocalePreferences.cpp
+++ b/Src/base/settings/LocalePreferences.cpp
@@ -324,7 +324,10 @@ void LocalePreferences::registerService()
     LSError error;
     LSErrorInit(&error);
 
-    ret = LSRegister(NULL, &m_lsHandle, &error);
+	char prefsServiceName[256] = {0};
+	snprintf(prefsServiceName, 255, "com.palm.systemmanager-localeprefs-%d", getpid());
+
+	ret = LSRegister(prefsServiceName, &m_lsHandle, &error);
     if (!ret) {
         g_critical("Failed to register handler: %s", error.message);
         LSErrorFree(&error);

--- a/Src/base/settings/Preferences.cpp
+++ b/Src/base/settings/Preferences.cpp
@@ -351,7 +351,10 @@ void Preferences::registerService()
 	LSError error;
 	LSErrorInit(&error);
 
-	ret = LSRegister(NULL, &m_lsHandle, &error);
+	char prefsServiceName[256] = {0};
+	snprintf(prefsServiceName, 255, "com.palm.systemmanager-prefs-%d", getpid());
+
+	ret = LSRegister(prefsServiceName, &m_lsHandle, &error);
 	if (!ret) {
 		g_critical("Failed to register handler: %s", error.message);
 		LSErrorFree(&error);


### PR DESCRIPTION
Use unique names for LSRegister

Fixes:

May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] LunaSysService TimePrefsHandler#4511 {"FUNC":"updateTimeZoneEnv"} TZ env is now [Etc/GMT-0]
May 01 14:38:51 qemux86-64 sleepd[573]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.webos.service.systemservice","CATEGORY":"/","METHOD":"set"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaSysService[509]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"getPreferences"} Service security groups don't allow method call.
May 01 14:38:51 qemux86-64 LunaAppManager[515]: Preferences::getPreferencesCallback(): toString -> [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]
May 01 14:38:51 qemux86-64 LunaAppManager[515]: LocalePreferences::getPreferencesCallback(): toString -> [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]
May 01 14:38:51 qemux86-64 LunaAppManager[515]: LocalePreferences::getPreferencesCallback(): toString -> [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]
May 01 14:38:51 qemux86-64 LunaAppManager[515]: LocalePreferences::getLocaleInfoCallback(): [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]
May 01 14:38:51 qemux86-64 LunaSysMgr[514]: Preferences::getPreferencesCallback(): toString -> [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]
May 01 14:38:51 qemux86-64 LunaSysMgr[514]: LocalePreferences::getPreferencesCallback(): toString -> [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]
May 01 14:38:51 qemux86-64 LunaSysMgr[514]: LocalePreferences::getPreferencesCallback(): toString -> [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]
May 01 14:38:51 qemux86-64 LunaSysMgr[514]: LocalePreferences::getLocaleInfoCallback(): [{"returnValue":false,"errorCode":-1,"errorText":"Denied method call \"getPreferences\" for category \"/\""}]

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>