### PR TITLE
Remove the workaround to include lunaservice.h

### DIFF
--- a/Src/base/hosts/HostArm.h
+++ b/Src/base/hosts/HostArm.h
@@ -36,7 +36,7 @@
 #if defined(HAS_HIDLIB)
 #include "HidLib.h"
 #endif
-#include "lunaservice.h"
+#include <luna-service2/lunaservice.h>
 
 #include <qsocketnotifier.h>
 #include <QObject>

--- a/include/JSONUtils.h
+++ b/include/JSONUtils.h
@@ -21,7 +21,7 @@
 
 #include "Settings.h"
 
-#include <lunaservice.h>
+#include <luna-service2/lunaservice.h>
 #include <pbnjson.h>
 #include <pbnjson.hpp>
 

--- a/include/LocalePreferences.h
+++ b/include/LocalePreferences.h
@@ -23,7 +23,7 @@
 #include "Common.h"
 
 #include <string>
-#include <lunaservice.h>
+#include <luna-service2/lunaservice.h>
 
 #include "Mutex.h"
 #include "CustomEvents.h"

--- a/include/Preferences.h
+++ b/include/Preferences.h
@@ -26,7 +26,7 @@
 
 #include <LocalePreferences.h>
 #include <string>
-#include <lunaservice.h>
+#include <luna-service2/lunaservice.h>
 
 #include "Mutex.h"
 #include "CustomEvents.h"


### PR DESCRIPTION
Use `luna-service2/lunaservice.h` instead.

This no longer works with latest LS2 from OSE, so let's fix this finally :)